### PR TITLE
Correção de tratamento de digest value

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -134,7 +134,7 @@ class Complements
             $dig = $infProt->getElementsByTagName("digVal")->item(0);
             $key = $infProt->getElementsByTagName("chBPe")->item(0)->nodeValue;
             if (isset($dig)) {
-                $digProt = base64_decode($dig->nodeValue);
+                $digProt = $dig->nodeValue;
                 if ($digProt == $digBPe && $chave == $key) {
                     //100 Autorizado
                     //150 Autorizado fora do prazo


### PR DESCRIPTION
O digest value retornado pela sefaz possuí o mesmo formato do enviado no XML, portanto não precisa de base64_decode. Na situação atual, o documento é aprovado, e ao chamar o addBPeProtocol, é lançada a exceção wrongDocument.