### PR TITLE
Removido espaços em branco e quebra de linha a esquerda apos remoção…

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -77,6 +77,7 @@ class Tools extends ToolsCommon
         $servico = 'BPeRecepcao';
         $sxml = implode("", $aXml);
         $sxml = preg_replace("/<\?xml.*?\?>/", "", $sxml);
+        $sxml = ltrim($sxml);
         $this->servico(
             $servico,
             $this->config->siglaUF,


### PR DESCRIPTION
… da tag <xml> para envio do xml comprimido. Com o espaço em branco, algumas UFs acusavam a rejeição 244 que diz que não pode haver caracteres de edição no começo, final ou entre as tags.